### PR TITLE
ci: group dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
-  # Rust (cargo workspace).
+  # Rust (cargo workspace). Group non-major bumps into one PR; majors stay
+  # individual so each is reviewed on its own.
   - package-ecosystem: cargo
     directory: "/"
     schedule:
@@ -8,8 +9,14 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "build"
+    groups:
+      cargo:
+        update-types:
+          - "minor"
+          - "patch"
 
-  # JS (pnpm workspace) — root manifest + workspace packages.
+  # JS (pnpm workspace). Split runtime vs tooling so app-affecting bumps are
+  # visible separately from dev-tooling churn; majors stay individual.
   - package-ecosystem: npm
     directory: "/"
     schedule:
@@ -17,11 +24,26 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "build"
+    groups:
+      npm-production:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-development:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # GitHub Actions.
+  # GitHub Actions rarely break across majors — group every update into one PR.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     commit-message:
       prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 📝 Description
<!-- Provide a clear and concise description of what this PR does -->
Enable **grouped Dependabot version updates** so dependency bumps arrive as a few
per-ecosystem PRs instead of one per dependency. Non-major (minor + patch) updates
are bundled; **major updates stay individual** so each is reviewed on its own. For
npm, runtime (`production`) and tooling (`development`) dependencies are grouped
separately so app-affecting changes are visible apart from dev-tooling churn.

Touches only `.github/dependabot.yml` — no application code.

## 🔗 Related Issues
<!-- Link related issues using keywords: closes, fixes, resolves, relates to -->
<!-- Example: Closes #123, Relates to #456 -->
N/A — maintenance/automation tuning (reduces the current ~one-PR-per-dependency noise).

## ❓ Type of Change
<!-- Mark the relevant option with an "x" (e.g., [x]) -->
- [ ] 🐞 **Bug fix** — Non-breaking change that fixes an issue
- [ ] 💡 **Feature Request** — Community-suggested feature implementation
- [x] 🔧 **Chore** — Maintenance tasks, dependency updates, CI/CD, etc.
- [ ] ✨ **Feature** — Approved/planned feature implementation
- [ ] ♻️ **Refactoring** — Code change that neither fixes a bug nor adds a feature
- [ ] 📚 **Documentation** — Changes to documentation only
- [ ] 💥 **Breaking change** — Fix or feature that would cause existing functionality to change
- [ ] 🧪 **Test** — Adding or updating tests

## 📋 Changes Made
<!-- Provide a bullet-point list of the changes made -->
- Add `groups` to each ecosystem in `.github/dependabot.yml`:
  - **cargo** → group `minor` + `patch` into one PR.
  - **npm** → two groups, `npm-production` and `npm-development`, each `minor` + `patch`.
  - **github-actions** → group all updates (`patterns: ["*"]`) into one PR.
- Majors remain ungrouped (one PR each) on purpose.

## 🧪 How to Test
<!-- Provide steps for reviewers to test your changes -->
1. Confirm `.github/dependabot.yml` is valid YAML and CI on this PR is green.
2. After merge, on the next weekly run (or via `@dependabot recreate` on an open
   PR), verify Dependabot opens **grouped** PRs (e.g. "bump the npm-development
   group with N updates") instead of one per dependency, with majors still individual.

## ✅ Checklist
### General
- [x] My code follows the project's coding standards and style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Noderium gates
- [x] Commit title follows **Conventional Commits**, lowercase subject (commitlint passes)
- [x] `just test` is green (cargo + frontend + editor latency p95 < 16ms)
- [x] `clippy -D warnings`, `fmt --check`, `lint`, and `format:check` all pass
- [ ] UI changes verified in **light and dark** (screenshots above if visual)
- [ ] **en-US and pt-BR** dictionaries kept in sync (if i18n touched)
- [x] FSD boundaries / pure domain crates respected (no Tauri/UI leakage into core)

### Documentation
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have updated the CHANGELOG (if applicable)

**Breaking changes description:** None.

## 🗒️ Additional Notes
<!-- Add any additional context, notes for reviewers, or anything else -->
- Grouping applies **going forward**; the ~12 currently open Dependabot PRs are
  **not** merged retroactively. To collapse them now, comment `@dependabot recreate`
  on one (or wait for the next weekly run).
- Design rationale: bundling patch/minor reduces noise, while keeping majors
  individual avoids a breaking major blocking the safe updates. The npm
  production/development split keeps runtime-dependency changes visible separately
  from dev-tooling churn. CI remains the safety net for pre-1.0 deps whose "minor"
  can still be breaking (e.g. `rusqlite 0.x`).