### PR TITLE
build(deps): update rusqlite to 0.40 and bump Rust to 1.96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1194,8 +1194,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -1434,15 +1434,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1455,20 +1446,26 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2031,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2422,7 +2419,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3259,10 +3256,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
@@ -3270,6 +3277,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -3705,6 +3713,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4920,7 +4940,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 [workspace.package]
 version = "0.0.1" # x-release-please-version
 edition = "2021"
-rust-version = "1.92"
+rust-version = "1.96"
 license = "Apache-2.0"
 repository = "https://github.com/leal32b/noderium"
 authors = ["Noderium contributors"]
@@ -30,7 +30,7 @@ authors = ["Noderium contributors"]
 # Third-party versions are centralized here; member crates opt in with
 # `<dep>.workspace = true` so versions can never drift across the workspace.
 thiserror = "2"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 loro = "1.13"
 rs-fsrs = "1.2"
 chrono = "0.4"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## 📝 Description
<!-- Provide a clear and concise description of what this PR does -->
Update `rusqlite` 0.32 → 0.40. It pulls `libsqlite3-sys` 0.38, whose build uses the
now-stable `cfg_select` and needs a newer compiler, so this also bumps the pinned
Rust toolchain **1.92 → 1.96** (current stable) and `rust-version` accordingly.

## 🔗 Related Issues
<!-- Link related issues using keywords: closes, fixes, resolves, relates to -->
<!-- Example: Closes #123, Relates to #456 -->
Update `rusqlite` 0.32 → 0.40. It pulls `libsqlite3-sys` 0.38, whose build uses the
now-stable `cfg_select` and needs a newer compiler, so this also bumps the pinned
Rust toolchain **1.92 → 1.96** (current stable) and `rust-version` accordingly.

## ❓ Type of Change
<!-- Mark the relevant option with an "x" (e.g., [x]) -->
- [ ] 🐞 **Bug fix** — Non-breaking change that fixes an issue
- [ ] 💡 **Feature Request** — Community-suggested feature implementation
- [x] 🔧 **Chore** — Maintenance tasks, dependency updates, CI/CD, etc.
- [ ] ✨ **Feature** — Approved/planned feature implementation
- [ ] ♻️ **Refactoring** — Code change that neither fixes a bug nor adds a feature
- [ ] 📚 **Documentation** — Changes to documentation only
- [ ] 💥 **Breaking change** — Fix or feature that would cause existing functionality to change
- [ ] 🧪 **Test** — Adding or updating tests

## 📋 Changes Made
<!-- Provide a bullet-point list of the changes made -->
- `rust-toolchain.toml`: channel `1.92.0` → `1.96.0`.
- `Cargo.toml`: `rust-version` `1.92` → `1.96`; `rusqlite` `0.32` → `0.40` (workspace dep).
- `Cargo.lock`: rusqlite + libsqlite3-sys (0.30 → 0.38) and transitive deps updated.

## 🧪 How to Test
<!-- Provide steps for reviewers to test your changes -->
1. `cargo build --workspace --exclude noderium-desktop` (compiles on 1.96; the
   `cfg_select` error on 1.92 is gone).
2. `cargo test --workspace --exclude noderium-desktop` → all green.
3. `cargo clippy --workspace --exclude noderium-desktop --all-targets -- -D warnings` → clean.
4. `cargo fmt --all -- --check` → clean. (Desktop/Tauri build is covered by the CI `desktop` job on the pinned 1.96.)

## ✅ Checklist
### General
- [x] My code follows the project's coding standards and style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Noderium gates
- [x] Commit title follows **Conventional Commits**, lowercase subject (commitlint passes)
- [x] `just test` is green (cargo + frontend + editor latency p95 < 16ms)
- [x] `clippy -D warnings`, `fmt --check`, `lint`, and `format:check` all pass
- [ ] UI changes verified in **light and dark** (screenshots above if visual)
- [ ] **en-US and pt-BR** dictionaries kept in sync (if i18n touched)
- [x] FSD boundaries / pure domain crates respected (no Tauri/UI leakage into core)

### Documentation
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have updated the CHANGELOG (if applicable)

### Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Delete this section if not applicable -->
- [ ] I have documented the breaking changes
- [ ] I have provided a migration guide (if needed)

**Breaking changes description:** Raises the project MSRV from **1.92 to 1.96**.
Contributors pick this up automatically via `rust-toolchain.toml` (rustup installs
1.96 on the next cargo command). No code/API changes.

## 🗒️ Additional Notes
<!-- Add any additional context, notes for reviewers, or anything else -->
Bumping off the Dec-2025 1.92 to the current stable is healthy hygiene and is what
unblocked rusqlite 0.40. clippy on 1.96 raised **no** new lints.