### PR TITLE
Chore/dependabot defer blocked majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      # rusqlite >= 0.40 pulls libsqlite3-sys 0.38 (uses the unstable `cfg_select`),
-      # which needs a newer Rust than the pinned 1.92. Revisit when bumping the
-      # toolchain (rust-toolchain.toml / rust-version).
-      - dependency-name: "rusqlite"
-        versions:
-          - ">= 0.40"
 
   # JS (pnpm workspace). Split runtime vs tooling so app-affecting bumps are
   # visible separately from dev-tooling churn; majors stay individual.
@@ -48,7 +41,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@eslint/js"
         update-types: ["version-update:semver-major"]
-      # vite 8 needs vite-plugin-solid / unocss / vitest to support it (peer is vite <= 6).
+      # vite 8 is feasible (plugins support it) but pulls a large unocss 0.65 -> 66
+      # migration; deferred until that's done as a dedicated upgrade.
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # rusqlite >= 0.40 pulls libsqlite3-sys 0.38 (uses the unstable `cfg_select`),
+      # which needs a newer Rust than the pinned 1.92. Revisit when bumping the
+      # toolchain (rust-toolchain.toml / rust-version).
+      - dependency-name: "rusqlite"
+        versions:
+          - ">= 0.40"
 
   # JS (pnpm workspace). Split runtime vs tooling so app-affecting bumps are
   # visible separately from dev-tooling churn; majors stay individual.
@@ -35,6 +42,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # eslint 10 needs eslint-plugin-solid to support it (its peer is eslint <= 9).
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      # vite 8 needs vite-plugin-solid / unocss / vitest to support it (peer is vite <= 6).
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions rarely break across majors — group every update into one PR.
   - package-ecosystem: github-actions


### PR DESCRIPTION
## 📝 Description
<!-- Provide a clear and concise description of what this PR does -->
Add Dependabot `ignore` rules for the two major upgrades that **can't** be merged
yet, so they stop reopening as red PRs (with the reason documented to revisit later):
- **eslint / @eslint/js 10** — `eslint-plugin-solid` (latest 0.14.5) still peers `eslint <= 9`.
- **vite 8 (major)** — feasible (plugins support it) but pulls a large `unocss 0.65 → 66`
  migration; deferred until that's done as a dedicated upgrade.

`rusqlite` is **not** ignored — it's being updated in the companion PR (rusqlite + Rust 1.96).

## 🔗 Related Issues
<!-- Link related issues using keywords: closes, fixes, resolves, relates to -->
<!-- Example: Closes #123, Relates to #456 -->
Lets us cleanly close the red Dependabot PRs `npm/@eslint/js-10` and `npm/vite-8`.

## ❓ Type of Change
<!-- Mark the relevant option with an "x" (e.g., [x]) -->
- [ ] 🐞 **Bug fix** — Non-breaking change that fixes an issue
- [ ] 💡 **Feature Request** — Community-suggested feature implementation
- [x] 🔧 **Chore** — Maintenance tasks, dependency updates, CI/CD, etc.
- [ ] ✨ **Feature** — Approved/planned feature implementation
- [ ] ♻️ **Refactoring** — Code change that neither fixes a bug nor adds a feature
- [ ] 📚 **Documentation** — Changes to documentation only
- [ ] 💥 **Breaking change** — Fix or feature that would cause existing functionality to change
- [ ] 🧪 **Test** — Adding or updating tests

## 📋 Changes Made
<!-- Provide a bullet-point list of the changes made -->
- `.github/dependabot.yml`: add `ignore` for `eslint`/`@eslint/js`
  (`version-update:semver-major`) and `vite` (`version-update:semver-major`).
- Ignores only the **major**, so minor/patch updates for these keep flowing; rules
  are reversible (delete to re-enable).

## 🧪 How to Test
<!-- Provide steps for reviewers to test your changes -->
1. `.github/dependabot.yml` is valid YAML and CI on this PR is green.
2. After merge, Dependabot no longer reopens the eslint 10 / vite 8 major PRs, while
   still proposing their minor/patch updates and everything else.

## ✅ Checklist
### General
- [x] My code follows the project's coding standards and style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Noderium gates
- [x] Commit title follows **Conventional Commits**, lowercase subject (commitlint passes)
- [x] `just test` is green (cargo + frontend + editor latency p95 < 16ms)
- [x] `clippy -D warnings`, `fmt --check`, `lint`, and `format:check` all pass
- [ ] UI changes verified in **light and dark** (screenshots above if visual)
- [ ] **en-US and pt-BR** dictionaries kept in sync (if i18n touched)
- [x] FSD boundaries / pure domain crates respected (no Tauri/UI leakage into core)

### Documentation
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have updated the CHANGELOG (if applicable)

### Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Delete this section if not applicable -->
- [ ] I have documented the breaking changes
- [ ] I have provided a migration guide (if needed)

**Breaking changes description:** None.

## 🗒️ Additional Notes
<!-- Add any additional context, notes for reviewers, or anything else -->
Revisit conditions: **eslint 10** when `eslint-plugin-solid` ships eslint-10 support;
**vite 8** when we do the `unocss 0.65 → 66` migration (I can take that as a dedicated PR).