### PR TITLE
build(frontend): load loro wasm under vite 8

### DIFF
--- a/apps/desktop/frontend/package.json
+++ b/apps/desktop/frontend/package.json
@@ -42,6 +42,7 @@
     "unocss": "^66.7.0",
     "vite": "^8.0.16",
     "vite-plugin-solid": "^2.11.0",
+    "vite-plugin-wasm": "^3.6.0",
     "vitest": "^4.1.8"
   }
 }

--- a/apps/desktop/frontend/vite.config.ts
+++ b/apps/desktop/frontend/vite.config.ts
@@ -3,12 +3,15 @@ import { fileURLToPath, URL } from 'node:url'
 import UnoCSS from 'unocss/vite'
 import { defineConfig } from 'vite'
 import solid from 'vite-plugin-solid'
+import wasm from 'vite-plugin-wasm'
 
 // Tauri expects a fixed port and ignores Vite's env vars; see ADR-004.
 const host = process.env['TAURI_DEV_HOST']
 
 export default defineConfig({
-  plugins: [UnoCSS(), solid()],
+  // loro-crdt's bundler build imports `.wasm` via ESM integration, which Vite 8's
+  // built-in wasm fallback rejects; vite-plugin-wasm serves it instead (ADR-002).
+  plugins: [wasm(), UnoCSS(), solid()],
   resolve: {
     alias: {
       '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
@@ -24,6 +27,11 @@ export default defineConfig({
   // wasm asset correctly.
   optimizeDeps: {
     exclude: ['@noderium/editor', 'loro-crdt', 'loro-prosemirror'],
+  },
+  // vite-plugin-wasm instantiates the wasm with top-level await; the bundle
+  // must emit it natively. Tauri only ships a modern webview, so target esnext.
+  build: {
+    target: 'esnext',
   },
   // Tauri integration: stable dev server, no clobbering of Rust build output.
   clearScreen: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       vite-plugin-solid:
         specifier: ^2.11.0
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite-plugin-wasm:
+        specifier: ^3.6.0
+        version: 3.6.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@22.19.20)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -4797,6 +4800,11 @@ packages:
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
+
+  vite-plugin-wasm@3.6.0:
+    resolution: {integrity: sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8
 
   vite@7.3.5:
     resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
@@ -10494,6 +10502,10 @@ snapshots:
       '@testing-library/jest-dom': 6.9.1
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-wasm@3.6.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## 📝 Description
<!-- Provide a clear and concise description of what this PR does -->
The Vite 8 upgrade (#27) broke `just dev` when opening the editor. Vite 8 hardened its WebAssembly handling, and its built-in `vite-wasm-fallback` plugin now **rejects** the ESM-integration `.wasm` import that loro-crdt's `bundler` build uses (`import * as rawWasm from "./loro_wasm_bg.wasm"`), pulled in transitively via `loro-prosemirror`. The Rust and Vitest suites stayed green because Vitest resolves loro-crdt's `nodejs` build, which loads the wasm differently — so the failure only surfaced at runtime in the dev server.

This PR serves the wasm asset with `vite-plugin-wasm` and sets the build target to `esnext` (the plugin instantiates the module with top-level await, and Noderium only runs in a modern Tauri webview).

## 🔗 Related Issues
<!-- Link related issues using keywords: closes, fixes, resolves, relates to -->
<!-- Example: Closes #123, Relates to #456 -->


## ❓ Type of Change
<!-- Mark the relevant option with an "x" (e.g., [x]) -->
- [x] 🐞 **Bug fix** — Non-breaking change that fixes an issue
- [ ] 💡 **Feature Request** — Community-suggested feature implementation
- [ ] 🔧 **Chore** — Maintenance tasks, dependency updates, CI/CD, etc.
- [ ] ✨ **Feature** — Approved/planned feature implementation
- [ ] ♻️ **Refactoring** — Code change that neither fixes a bug nor adds a feature
- [ ] 📚 **Documentation** — Changes to documentation only
- [ ] 💥 **Breaking change** — Fix or feature that would cause existing functionality to change
- [ ] 🧪 **Test** — Adding or updating tests

## 📋 Changes Made
<!-- Provide a bullet-point list of the changes made -->
- Add `vite-plugin-wasm` (frontend devDep) to serve the loro-crdt /  loro-prosemirror `.wasm` instead of the `builtin:vite-wasm-fallback`.
- Set `build.target: 'esnext'` in `vite.config.ts`: the plugin instantiates the wasm with top-level await, so the production bundle must emit it natively.
- Keep `optimizeDeps.exclude` (esbuild's pre-bundle also can't handle the ESM `.wasm` import).
- Considered and dropped `vite-plugin-top-level-await`: with the `esnext` target it's unnecessary, and it broke `vite build` by failing to down-level TLA.

## 🧪 How to Test
<!-- Provide steps for reviewers to test your changes -->
1. `pnpm install` (pulls in `vite-plugin-wasm`).
2. `just dev` and open the **/editor** route — the
   `"ESM integration proposal for Wasm" is not supported` error should be gone;
   the editor loads its blocks and the latency meter is active.
3. `pnpm --filter @noderium/desktop-frontend run build` — the production build
   completes and emits `dist/assets/loro_wasm_bg-*.wasm` as an asset.

## ✅ Checklist
### General
- [x] My code follows the project's coding standards and style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Noderium gates
- [x] Commit title follows **Conventional Commits**, lowercase subject (commitlint passes)
- [ ] `just test` is green (cargo + frontend + editor latency p95 < 16ms)
- [ ] `clippy -D warnings`, `fmt --check`, `lint`, and `format:check` all pass
- [ ] UI changes verified in **light and dark** (screenshots above if visual)
- [ ] **en-US and pt-BR** dictionaries kept in sync (if i18n touched)
- [x] FSD boundaries / pure domain crates respected (no Tauri/UI leakage into core)

### Documentation
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have updated the CHANGELOG (if applicable)

## 🗒️ Additional Notes
<!-- Add any additional context, notes for reviewers, or anything else -->
Before merging, it's worth running the full `just test` in CI to close the Rust gates (cargo + the editor latency spike), which I didn't re-run locally since the patch is frontend-config only.